### PR TITLE
Ensure to limit the access to an AKS API server to a limited IP range

### DIFF
--- a/Terraform-AZURE-Services-Creation/AKS/main.tf
+++ b/Terraform-AZURE-Services-Creation/AKS/main.tf
@@ -89,8 +89,11 @@ resource "azurerm_kubernetes_cluster" "k8s" {
       admin_group_object_ids = [var.aks_admins_group_object_id]
     }
   }
-
+  api_server_authorized_ip_ranges = [
+    "192.0.2.0/24"
+  ]
 }
+
 
 data "azurerm_resource_group" "node_resource_group" {
   name = azurerm_kubernetes_cluster.k8s.node_resource_group


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

It is better to limit the access to the AKS API server in an AKS control plane to a limited IP range to mitigate unexpected attacks.

