### PR TITLE
Ensure to configure a network policy

### DIFF
--- a/Terraform-AZURE-Services-Creation/AKS/main.tf
+++ b/Terraform-AZURE-Services-Creation/AKS/main.tf
@@ -75,12 +75,11 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     }
 
   }
-
   network_profile {
     load_balancer_sku = "standard"
     network_plugin    = "azure"
+    network_policy = "calico"
   }
-
   role_based_access_control {
     enabled = var.kubernetes_cluster_rbac_enabled
 
@@ -89,8 +88,8 @@ resource "azurerm_kubernetes_cluster" "k8s" {
       admin_group_object_ids = [var.aks_admins_group_object_id]
     }
   }
-
 }
+
 
 data "azurerm_resource_group" "node_resource_group" {
   name = azurerm_kubernetes_cluster.k8s.node_resource_group


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description 
It is better to configure NetworkPolicy to control traffic to pods. In the default settings, there are no restrictions and a pod can find and communicate with any other pods.

